### PR TITLE
add newlines before block/style changes to pacify md-to-pdf tooling

### DIFF
--- a/doc/howToBuildADuck.md
+++ b/doc/howToBuildADuck.md
@@ -128,7 +128,9 @@ Navigate to the downloaded ClusterDuck Protocol Folder and select.
 Return to the _Sketch > Include Library menu._ menu. You should now see the library at the bottom of the drop-down menu. It is ready to be used in your sketch. The zip file will have been expanded in the _libraries_ folder in your Arduino sketches directory.
 
 #### Manual Install
+
 You will need to clone the ClusterDuck Protocol onto your local machine and include the libraries folder into your local arduino libraries folder.
+
 1. Clone the ClusterDuck Protocol onto your local machine `git clone https://github.com/Code-and-Response/ClusterDuck-Protocol.git`
 1. Pull all the Library submodules needed for the Arduino IDE `git submodule update --init --recursive`
 1. Copy the `ClusterDuck-Protocol`folder into your local Arduino Libraries folder **MacOs** _/Users/USER/Documents/Arduino/_. **windows** _C:/Users/USER/Documents/Arduino._
@@ -255,6 +257,7 @@ DuckLink Hardware and Firmware Assembly
     Finished Duck:
 
     ![Running duck example](./assets/images/setup.png "Running duck example")
+
 ## Setting up the IBM Watson IoT Platform
 
 1. Create an IBM Cloud account through [this link](https://ibm.biz/BdqiVW). Fill out all the required information and confirm your email address.


### PR DESCRIPTION
just some added empty lines to fix rendering issues in the PDF version of HowToBuildADuck.
the to-PDF tooling seems to be more picky about markdown interpretation than the webviewer. 

Not-Just-Signed-Off-By-But-Actually-Signed: gozu42 <tvguho-tbmh42-tct.76b2756e@hashmail.org>