### PR TITLE
cleanup logging, some bugfixing

### DIFF
--- a/ClusterDuck.cpp
+++ b/ClusterDuck.cpp
@@ -373,7 +373,7 @@ void ClusterDuck::runMamaDuck() {
       }
     } else {
       // Serial.println("Byte code not recognized!");
-      memset(transmission, 0x00, pSize); //Reset transmission
+      memset(transmission, 0x00, 250); //Reset transmission
       packetIndex = 0;
 
      }

--- a/ClusterDuck.cpp
+++ b/ClusterDuck.cpp
@@ -673,25 +673,20 @@ String ClusterDuck::duckMac(boolean format)
 
 //Create a uuid
 String ClusterDuck::uuidCreator() {
-  byte randomValue;
-  char msg[50];
-  int numBytes = 0;
+  String msg = "";
   int i;
 
-  numBytes = atoi("8");
-  if (numBytes > 0)
-  {
-    memset(msg, 0, sizeof(msg));
-    for (i = 0; i < numBytes; i++) {
-      randomValue = random(0, 37);
-      msg[i] = randomValue + 'a';
-      if (randomValue > 26) {
-        msg[i] = (randomValue - 26) + '0';
+  for (i = 0; i < 8; i++) {
+      byte randomValue = random(0, 36);
+      if (randomValue < 26) {
+        msg = msg + char(randomValue + 'a');
+      } else {
+        msg = msg + char((randomValue - 26) + '0');
       }
-    }
   }
-
-  return String(msg);
+  Serial.print("uuidCreator ");
+  Serial.println(msg);
+  return msg;
 }
 
 //Getters

--- a/ClusterDuck.cpp
+++ b/ClusterDuck.cpp
@@ -496,7 +496,11 @@ String * ClusterDuck::getPacketData(int pSize) {
   packetIndex = 0;
   int len = 0;
   byte byteCode;
-  bool sId, mId, pLoad, pth, ping;
+  bool sId = false;
+  bool mId = false;
+  bool pLoad = false;
+  bool pth = false;
+  bool ping = false;
   String msg = "";
   bool gotLen = false;
 


### PR DESCRIPTION
briefly commenting on the individual commits.
let me know if you prefer to get stuff like this as individual pull requests.
i filed this as one PR for now to avoid additional merge commits.

first is mainly just a cleanup of the Serial.print debuglogging to make it easier to figure out where all the quacking on serial is coming from, and why.
as a next step (once i get tired by too much logging) i would like to add some minimal #define "logging framework" that toggles these debugprints based on a #defined loglevel.

the changed memset avoids hard crashes on receive errors, but really also needs the transmission buffer size replaced by a #define to avoid inconsistent assumptions about the buffer size.
i would also like to change most of the other memset to use the same define.
as in, the "added overhead" from zapping the whole buffer each time instead of just a prefix is minimal, and it makes the whole operation more consistent or at least less likely to depend on anything external.

the initialize-to-false mainly stops the printed emtpy-fields when parsing ghost packets, that investigation is ongoing.

the changed uuidCreator changes the charset from "a-z{1-9:" to "a-z0-9" (which afaict was the original intent of the code). this might lead to problems downstream due to the introduced "0" if anything wants to interpret the ID-string as number.
there is also a concern about the use of String() here, it might lead to more rapid memory fragementation or even leaking. since the rest of the code uses the String() class already, this doesnt seem like an immediate problem and i have an investigation ongoing for this.
(== i still dont really understand c++ OO memory management in the Arduino framework, but reporting memory pool status details is part of my test-duck-telemetry now)