### PR TITLE
Add Password protection for OTA updates

### DIFF
--- a/ClusterDuck.cpp
+++ b/ClusterDuck.cpp
@@ -17,8 +17,12 @@ String password = "";
 
 String ClusterDuck::_deviceId = "";
 
-  bool restartRequired = false;
-  size_t content_len;
+bool restartRequired = false;
+size_t content_len;
+
+//Username and password for /update 
+const char* http_username = CDPCFG_UPDATE_USERNAME;
+const char* http_password = CDPCFG_UPDATE_PASSWORD;
 
 
 ClusterDuck::ClusterDuck() {
@@ -170,6 +174,8 @@ void ClusterDuck::setupWebServer(bool createCaptivePortal) {
 
 // Update Firmware OTA
      webServer.on("/update", HTTP_GET, [&](AsyncWebServerRequest *request){
+               if(!request->authenticate(http_username, http_password))
+               return request->requestAuthentication();
               
                 AsyncWebServerResponse *response = request->beginResponse(200, "text/html", update_page);
                 
@@ -910,6 +916,8 @@ void ClusterDuck::setColor(int red, int green, int blue)
 DNSServer ClusterDuck::dnsServer;
 const char * ClusterDuck::DNS  = "duck";
 const byte ClusterDuck::DNS_PORT = 53;
+
+
 
 int ClusterDuck::_rssi = 0;
 float ClusterDuck::_snr;

--- a/cdpcfg.h
+++ b/cdpcfg.h
@@ -1,27 +1,37 @@
 #ifndef CDPCFG
 #define CDPCFG
 
+// Username and Password for OTA web page
+#define CDPCFG_UPDATE_USERNAME "username"
+#define CDPCFG_UPDATE_PASSWORD "password"
 
+
+// Baud Rate
 #define CDPCFG_SERIAL_BAUD 115200
 
+// Oled Display settings
 #define CDPCFG_PIN_OLED_CLOCK 15
 #define CDPCFG_PIN_OLED_DATA   4
 #define CDPCFG_PIN_OLED_RESET 16
 
 
+// Acces point IP adress
 #define CDPCFG_AP_IP1 192
 #define CDPCFG_AP_IP2 168
 #define CDPCFG_AP_IP3 1
 #define CDPCFG_AP_IP4 1
 
 
+// Asynwevserver Port
 #define CDPCFG_WEB_PORT 80
 
 
+//Lora configurations
 #define CDPCFG_PIN_LORA_CS   18
 #define CDPCFG_PIN_LORA_DIO0 26
 #define CDPCFG_PIN_LORA_DIO1 25
 #define CDPCFG_PIN_LORA_RST  14
+
 
 #define CDPCFG_RF_LORA_FREQ  915.0
 #define CDPCFG_RF_LORA_BW    125.0
@@ -35,14 +45,18 @@
 
 #define CDPCFG_CDP_BUFSIZE 250
 
+//Timer in milliseconds
 #define CDPCFG_MILLIS_ALIVE   1800000
 #define CDPCFG_MILLIS_REBOOT 43200000
 
 #define CDPCFG_UUID_LEN 8
 
+
+//Led Pins
 #define CDPCFG_PIN_RGBLED_R 25
 #define CDPCFG_PIN_RGBLED_G  4
 #define CDPCFG_PIN_RGBLED_B  2
+
 
 
 #endif // CDPCFG

--- a/cdpcfg.h
+++ b/cdpcfg.h
@@ -22,7 +22,7 @@
 #define CDPCFG_AP_IP4 1
 
 
-// Asynwevserver Port
+// Asyncwebserver Port
 #define CDPCFG_WEB_PORT 80
 
 
@@ -49,6 +49,7 @@
 #define CDPCFG_MILLIS_ALIVE   1800000
 #define CDPCFG_MILLIS_REBOOT 43200000
 
+//length of the uuid
 #define CDPCFG_UUID_LEN 8
 
 


### PR DESCRIPTION
I added a Username and Password protection for the /update URL so only the owner of the duck is able to reflash it.

Username and password are set to default in the CDPCFG.h file on the top:

`#define CDPCFG_UPDATE_USERNAME "username"
#define CDPCFG_UPDATE_PASSWORD "password"
`