### PR TITLE
54 quickstart first light

### DIFF
--- a/ClusterDuck.cpp
+++ b/ClusterDuck.cpp
@@ -386,6 +386,18 @@ void ClusterDuck::runMamaDuck() {
 
 }
 
+String tohex(byte *data, int size) {
+  String buf = "";
+  buf.reserve(size*2);
+  char *cs = "0123456789abcdef";
+  for (int i=0; i<size; i++) {
+    byte val = data[i];
+    buf += cs[(val>>4) & 0x0f];
+    buf += cs[ val     & 0x0f];
+  }
+  return buf;
+}
+
 int ClusterDuck::handlePacket() {
   int pSize = lora.getPacketLength();
   memset(transmission, 0x00, CDPCFG_CDP_BUFSIZE); //Reset transmission
@@ -396,6 +408,21 @@ int ClusterDuck::handlePacket() {
     // packet was successfully received
     Serial.print("handlePacket pSize ");
     Serial.println(pSize);
+
+    // dump received packet stats+data
+    Serial.print("LORA RCV");
+    Serial.print(" millis:");
+    Serial.print(millis());
+    Serial.print(" rssi:");
+    Serial.print(lora.getRSSI());
+    Serial.print(" snr:");
+    Serial.print(lora.getSNR());
+    Serial.print(" fe:");
+    Serial.print(lora.getFrequencyError());
+    Serial.print(" size:");
+    Serial.print(pSize);
+    Serial.print(" data:");
+    Serial.println(tohex(transmission, pSize));
 
     return pSize;
   } else {
@@ -752,6 +779,16 @@ void ClusterDuck::startReceive() {
 void ClusterDuck::startTransmit() {
   bool oldEI = enableInterrupt;
   enableInterrupt = false;
+
+  // dump send packet stats+data
+  Serial.print("LORA SND");
+  Serial.print(" millis:");
+  Serial.print(millis());
+  Serial.print(" size:");
+  Serial.print(packetIndex);
+  Serial.print(" data:");
+  Serial.println(tohex(transmission, packetIndex));
+
   int state = lora.transmit(transmission, packetIndex);
 
   memset(transmission, 0x00, CDPCFG_CDP_BUFSIZE); //Reset transmission

--- a/examples/TelemetryDuck/TelemetryDuck.ino
+++ b/examples/TelemetryDuck/TelemetryDuck.ino
@@ -1,0 +1,81 @@
+/* 
+   this is a mamaduck that sends some basic data quacks every now and then
+   it is useful as a quickstart example since it doesnt need any configuration
+   it reports some basic/crude stats like 
+   - cpu situation (millis+loopcount)
+   - memory situation (free and fragmentation)
+   - temperature (from sx127x sensor)
+   - battery level (from battery pin)
+
+*/
+
+// pin definitions for "heltec lora v2"
+#define PIN_BAT  37
+#define PIN_VEXT 21
+
+// this is currently required to access the sx127x temperature sensor
+#include <RadioLib.h>
+extern SX1276 lora;
+
+#include <ClusterDuck.h>
+#include "timer.h"
+
+auto timer = timer_create_default(); // create a timer with default settings
+
+// the ID will be autoreplaced by the last four digits of the MAC
+String myid = "blah";
+
+ClusterDuck duck;
+
+void setup() {
+  // use last 16 bit of MAC as duck-id
+  uint64_t chipid = ESP.getEfuseMac();
+  myid = String((uint16_t)(chipid>>32),HEX);
+
+  // switch on vext (so we can read the battery voltage)
+  pinMode(PIN_VEXT,OUTPUT);
+  digitalWrite(PIN_VEXT,LOW);
+
+  // standard mama setup
+  duck.begin();
+  duck.setDeviceId(myid);
+  duck.setupMamaDuck();
+
+  // dont send a quack right at startup 
+  // this avoids spectrum spam in brownout rapid-reboot-loop situations
+  schedSensor();
+  Serial.println("SETUP DONE");
+}
+
+void schedSensor() {
+  // send a sensor quack every 45-75 seconds
+  timer.in(45000+random(30000), runSensor);
+}
+
+uint32_t loopCount = 0;
+void loop() {
+  loopCount++;
+  timer.tick();
+  duck.runMamaDuck();
+}
+
+bool runSensor(void *) {
+
+  uint16_t raw = analogRead(PIN_BAT);
+
+  int8_t temp = lora.getTempRaw();
+
+  String sensorVal = "myid:" + myid + " millis:" + String(millis(),DEC) + " lc:" + String(loopCount,DEC) +
+	" bat:" + String(raw,DEC) + 
+	" gFH:" + String(ESP.getFreeHeap(),DEC) +
+	" gMFH:" + String(ESP.getMinFreeHeap(),DEC) +
+	" gMAH:" + String(ESP.getMaxAllocHeap(),DEC) +
+	" temp:" + String(temp,DEC);
+
+  schedSensor();
+
+  Serial.println("SENSOR: " + sensorVal);
+  duck.sendPayloadMessage(sensorVal);
+  
+  return true;
+}

--- a/examples/quickstart/duckster.pl
+++ b/examples/quickstart/duckster.pl
@@ -1,0 +1,278 @@
+#!/usr/bin/perl
+
+# this is an example quack-receiver that 
+# - reads from serial port (or logfile)
+# - should not require installing any perl modules
+# - parses the lora messages
+# - sends them on 
+# - - to a terminal and/or
+# - - to a logfile and/or
+# - - to a grafana and/or
+# - - to whatever you add modules for
+#
+# only the --infile is really required:
+# 	perl duckster.pl -i /dev/ttyUSB0
+#
+# more complete:
+# 	perl duckster.pl --infile /dev/ttyUSB0 --logfile duck.log --DEBUG 
+#
+
+use warnings;
+use strict;
+
+# optional for fractional seconds
+eval { require Time::HiRes; };
+
+my $infile;
+my $baud = 115200;
+
+my $logfile;
+my $DEBUG = 0;
+
+# process options 
+use Getopt::Long;
+Getopt::Long::Configure('bundling');
+unless (GetOptions(
+        'infile|i=s'    => \$infile,
+        'logfile|l=s'   => \$logfile,
+        'baud|b=s'      => \$baud,
+        'debug|D+'      => \$DEBUG,
+)) {
+        terminate('UNKNOWN', 'FATAL: error parsing options');
+}
+
+die "no infile" unless defined $infile && length $infile;
+die "infile '$infile' doesnt exist" unless -e $infile;
+
+my $lf;
+if (defined $logfile && length $logfile) {
+	use IO::Handle;
+	open $lf, ">>", $logfile or die "open($logfile): $!";
+}
+
+REOPEN:
+if ( -c $infile && $baud ) {
+	my $cmd = "stty -F $infile $baud raw -echo";
+	print "PORTSETUP: '$cmd'\n" if $DEBUG;
+	my $out = `$cmd`;
+	print "OUTPUT: '$out'\n" if $DEBUG;
+}
+open IF, "<", $infile or die "open($infile): $!";
+my $C=0;
+RETAIL:
+while (<IF>) {
+	$C=0;
+
+	# parse line
+	my $h = &line_to_hash($_);
+	next unless defined $h && ref $h eq "HASH";
+
+	# this is an example payload that just dumps the hash
+	use Data::Dumper;
+	$Data::Dumper::Sortkeys = 1;
+	print Dumper($h);
+
+	# ADD YOUR PAYLOAD HERE
+
+	# this payload sends the data to grafana via tcp
+	#&hash_to_carb($h);
+}
+print STDERR "SLEEP $C\n";
+sleep 10;
+goto RETAIL if $C++ < 30;
+&decarb();
+
+exit 0;
+
+####
+
+sub line_to_hash ($) {
+	my ($l,) = @_;
+	$l =~ s/[\r\n]+$//;
+	my $o = $l;
+	my $ts = eval { Time::HiRes::time(); } || time;
+	if ($l =~ s/^(\d+(\.\d+)?) //) {
+		# reuse existing timestamp?
+		$ts = $1;
+	}
+	if (defined $lf) {
+		print $lf "$ts $l\n";
+		$lf->flush() or die "cant flush $logfile";
+	}
+	unless ($l =~ s/^LORA (RCV|SND) //) {
+		print STDERR "IGNORED: '$o'\n" if $DEBUG;
+		return;
+	}
+	print STDERR "PARSING: '$o'\n" if $DEBUG;
+	my $verb = $1;
+
+	my %d = ( 
+		ts   => $ts, 
+		verb => $verb,
+		);
+
+	# soak up generic key:val pairs
+	while ($l =~ s/^(\w+):(-?\d+(\.\d+)?) //) {
+		my ($k,$v,) = ($1,$2,);
+		if (exists $d{$k}) {
+			die "dupe key $k in $o";
+		}
+		$d{$k} = $v;
+	}
+
+	# data: is last attr
+	unless ($l =~ s/^data://) {
+		die "no data in $_";
+	}
+	unless (defined $d{size}) {
+		die "no size in $o";
+	}
+	$l =~ s/ //g;
+	unless ((length $l) == ($d{size}*2)) {
+		die "bad size in $o";
+	}
+	my $d = pack "H*",$l;
+        unless (length $d == $d{size}) {
+		die "bad packed length";
+	}	
+
+	unless ($d =~ /^\xf5/) {
+		warn "NOCDP: $o";
+		return;
+	}
+
+	while (length $d > 1) {
+		my $O = substr $d, 0, 8;
+		my $t = substr $d, 0, 1, "";
+		my $l = ord substr $d, 0, 1, "";
+		my $v = substr $d, 0, $l, "";
+		my $T = {
+			chr(0xf8) => 'iamhere',
+			chr(0xf7) => 'payload',
+			chr(0xf6) => 'msgid',
+			chr(0xf5) => 'sndid',
+			chr(0xf4) => 'ping',
+			chr(0xf3) => 'path',
+			}->{$t} || "";
+		#die "unmatched tag ".ord($t)." in ".unpack("H*",$O)." in $o" unless length $T;
+		unless (length $T) {
+			warn "unmatched tag ".ord($t)." in ".unpack("H*",$O)." in $o";
+			last;
+		}
+		$v =~ s/\x00$//;
+		my $k = "cdp_$T";
+		if (exists $d{$k}) {
+			die "dupe key $k in $o";
+		}
+		$d{$k} = $v;
+
+		if ($T eq 'payload' && $v =~ /^myid:/) {
+			while ($v =~ s/^(\w+):([-\w]+)( |$)//) {
+				my ($K,$V)=(lc $1, $2);
+				my $k = "cdp_pl_$K";
+				if (exists $d{$k}) {
+					die "dupe key $k in $o";
+				}
+				$d{$k} = $V;
+			}
+		}
+	}
+	return \%d;
+}
+
+
+my %SEEN;
+sub line_to_carb {
+	my ($h,) = @_;
+	my %d = %$h;
+	my $ts = $d{ts};
+	die "no ts" unless defined $ts && $ts;
+	my $s = "";
+	my $pl = 0;
+	if (defined($d{cdp_path}) && $d{cdp_path} =~ /(?:,|^)(\w+)$/)  { 
+		$s = $1;
+		my $p = $d{cdp_path};
+		$p =~ s/[^,]+//g;
+		$pl = 1 + length $p;
+	}
+	for (qw/size rssi snr fe/) {
+		next unless defined $d{$_};
+		&carb("lora.all.$_", $d{$_}, $ts);
+		if ($pl) {
+			&carb("lora.$s.$_", $d{$_}, $ts);
+		}
+	}
+	if ($pl)  { 
+		&carb("lora.$s.pathlen", $pl, $ts);
+	}
+
+	if (defined $d{cdp_sndid} && (!($SEEN{$d{cdp_payload}}++))) {
+		my $S = $d{cdp_sndid};
+		unless ($S =~ /^\w+$/) {
+			warn "BADSND: '$S'";
+			next;
+		}
+		my $QS = quotemeta $S;
+		if ($d{cdp_path} !~ /^$QS(,|$)/) {
+			warn "BADPATH: '$S' vs '".$d{cdp_path}."'";
+		}
+		&carb("cdp.$S.plsize", length($d{cdp_payload}), $ts);
+		if ($pl)  { 
+			&carb("cdp.$S.pathlen", $pl, $ts);
+		}
+		for my $t (qw/bat temp gfh gmah gmfh/) {
+			my $v = $d{"cdp_pl_$t"};
+			next unless defined $v;
+			&carb("cdp.$S.$t", $v, $ts);
+		}
+	}
+}
+
+my %CC;
+my $CT;
+sub carb {
+	my ($k, $v, $t,) = @_;
+	return unless defined $v;
+	die "bad path $k" unless $k =~ /^[.\w]+$/;
+	$t ||= time;
+	my $cstep = 60;
+	my $T = int($cstep * int($t/$cstep));
+	if (defined $CT && $CT != $T) {
+		&decarb();
+	}
+	$CT = $T;
+
+	if (!exists $CC{$k}) {
+		$CC{$k} = {
+			cnt => 1,
+			sum => $v,
+			min => $v,
+			max => $v,
+			};
+	} else {
+		$CC{$k}{cnt}++;
+		$CC{$k}{sum}+=$v;
+		$CC{$k}{min} = ($CC{$k}{min} > $v) ? $v : $CC{$k}{min};
+		$CC{$k}{max} = ($CC{$k}{max} < $v) ? $v : $CC{$k}{max};
+	}
+}
+
+sub decarb {
+	return unless defined $CT;
+	use IO::Socket::INET;
+	for my $k (sort keys %CC) {
+	my $sock = IO::Socket::INET->new(PeerAddr => 'localhost:2003');
+	die "no sock" unless defined $sock && $sock;
+		my $K = $CC{$k};
+		for my $t (sort keys %$K) {
+			my $v = $K->{$t};
+			print "CARB: $k.$t $v $CT\n";
+			#print CF "$k.$t $v $CT\n";
+			print $sock "$k.$t $v $CT\n";
+		}
+	close $sock;
+	}
+	%CC = ();
+	$CT = undef;
+}
+


### PR DESCRIPTION
first shot at https://github.com/Code-and-Response/ClusterDuck-Protocol/issues/54

this adds 
* a debugprint to CDP itself (which is a souped-up version of what i used as part of the ghost packet hunt).
* a example TelemetryDuck (which is basicly just a zero-setup mama that quacks about how it feels every minute or so)
* a minimal "no modules required" perl script that reads from a serial port and parses the LORA packets it sees.

so the minimal-quickstart setup for getting some quacks is
- flash two or more heltecs with the telemetryduck sketch
- keep one of them attached to a computer running the duckster.pl script
- watch them quacking... done. 

the script is perl, which is not ideal, but in general installed on anything that is vaguely unixoid from raspi to mac.
it currently does not _require_ any additional modules to be installed.
adding more outputs (like a dms-lite compatible sqlite writer) is trivial though.

