### PR TITLE
Kw25 collection of minor features and fixups

### DIFF
--- a/ClusterDuck.cpp
+++ b/ClusterDuck.cpp
@@ -500,6 +500,18 @@ void ClusterDuck::runMamaDuck() {
 
 }
 
+String tohex(byte *data, int size) {
+  String buf = "";
+  buf.reserve(size*2);
+  char *cs = "0123456789abcdef";
+  for (int i=0; i<size; i++) {
+    byte val = data[i];
+    buf += cs[(val>>4) & 0x0f];
+    buf += cs[ val     & 0x0f];
+  }
+  return buf;
+}
+
 int ClusterDuck::handlePacket() {
   int pSize = lora.getPacketLength();
   memset(transmission, 0x00, CDPCFG_CDP_BUFSIZE); //Reset transmission
@@ -510,6 +522,21 @@ int ClusterDuck::handlePacket() {
     // packet was successfully received
     Serial.print("handlePacket pSize ");
     Serial.println(pSize);
+
+    // dump received packet stats+data
+    Serial.print("LORA RCV");
+    Serial.print(" millis:");
+    Serial.print(millis());
+    Serial.print(" rssi:");
+    Serial.print(lora.getRSSI());
+    Serial.print(" snr:");
+    Serial.print(lora.getSNR());
+    Serial.print(" fe:");
+    Serial.print(lora.getFrequencyError());
+    Serial.print(" size:");
+    Serial.print(pSize);
+    Serial.print(" data:");
+    Serial.println(tohex(transmission, pSize));
 
     return pSize;
   } else {
@@ -866,6 +893,16 @@ void ClusterDuck::startReceive() {
 void ClusterDuck::startTransmit() {
   bool oldEI = enableInterrupt;
   enableInterrupt = false;
+
+  // dump send packet stats+data
+  Serial.print("LORA SND");
+  Serial.print(" millis:");
+  Serial.print(millis());
+  Serial.print(" size:");
+  Serial.print(packetIndex);
+  Serial.print(" data:");
+  Serial.println(tohex(transmission, packetIndex));
+
   int state = lora.transmit(transmission, packetIndex);
 
   memset(transmission, 0x00, CDPCFG_CDP_BUFSIZE); //Reset transmission

--- a/cdpcfg.h
+++ b/cdpcfg.h
@@ -1,3 +1,27 @@
+/*
+ * CDP central compile-time configuration
+ *
+ * it will include optional 
+ * - cdpcfg-pre.h at the beginning
+ * - cdpcfg-post.h at the end
+ *
+ * to customize your build, you could ... 
+ * - edit this file or 
+ * - copy it to cdpcfg-pre.h and edit _that_ or 
+ * - create a from-scratch cdpcfg-pre.h that just overrides f.ex. the board defines or
+ * - create a cdpcfg-post.h to undef/define just parts
+ */
+
+// preload optional pre-cfg
+#ifndef CRPCFG_PRE
+  #define CRPCFG_PRE
+  #if __has_include("cdpcfg-pre.h")
+    #include "cdpcfg-pre.h"
+  #endif
+#endif
+
+
+// this is the actual main configuration section
 #ifndef CDPCFG
 #define CDPCFG
 
@@ -61,3 +85,13 @@
 
 
 #endif // CDPCFG
+
+
+// append optional post-cfg
+#ifndef CRPCFG_POST
+  #define CRPCFG_POST
+  #if __has_include("cdpcfg-post.h")
+    #include "cdpcfg-post.h"
+  #endif
+#endif
+

--- a/cdpcfg.h
+++ b/cdpcfg.h
@@ -31,9 +31,32 @@
    */ 
  
 
+  // BOARD "ttgo lora" not-tbeam
+  // https://github.com/Xinyuan-LilyGO/TTGO-LoRa-Series
+  #if defined(ARDUINO_TTGO_LoRa32_V1)
+    #define CDPCFG_PIN_BAT 35
+    #define CDPCFG_BAT_MULDIV 200/100
+
+    #define CDPCFG_PIN_LED1 25
+
+    //Lora configurations
+    #define CDPCFG_PIN_LORA_CS   18
+    #define CDPCFG_PIN_LORA_DIO0 26
+    #define CDPCFG_PIN_LORA_RST  23
+
+    // Oled Display settings
+    #define CDPCFG_PIN_OLED_CLOCK 22
+    #define CDPCFG_PIN_OLED_DATA  21
+
+    // actualy missing
+    #define CDPCFG_PIN_OLED_RESET -1
+    #define CDPCFG_PIN_LORA_DIO1  -1
+
+
+
   // BOARD "heltec lora v2"
   // https://heltec.org/project/wifi-lora-32/
-  #if defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
+  #elif defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
 
     #define CDPCFG_PIN_BAT  37
     #define CDPCFG_BAT_MULDIV 320/100

--- a/cdpcfg.h
+++ b/cdpcfg.h
@@ -25,63 +25,83 @@
 #ifndef CDPCFG
 #define CDPCFG
 
-// Username and Password for OTA web page
-#define CDPCFG_UPDATE_USERNAME "username"
-#define CDPCFG_UPDATE_PASSWORD "password"
+  /*
+   * HARDWARE SECTION // BOARD PINS
+   * the ARDUINO_* defs are set by the arduino build env
+   */ 
+ 
+
+  // BOARD "heltec lora v2"
+  // https://heltec.org/project/wifi-lora-32/
+  #if defined(ARDUINO_HELTEC_WIFI_LORA_32_V2)
+
+    #define CDPCFG_PIN_BAT  37
+    #define CDPCFG_BAT_MULDIV 320/100
+
+    #define CDPCFG_PIN_VEXT 21
+
+    #define CDPCFG_PIN_LED1 25
+
+    //Lora configurations
+    #define CDPCFG_PIN_LORA_CS   18
+    #define CDPCFG_PIN_LORA_DIO0 26
+    #define CDPCFG_PIN_LORA_RST  14
+
+    // Oled Display settings
+    #define CDPCFG_PIN_OLED_CLOCK 15
+    #define CDPCFG_PIN_OLED_DATA   4
+    #define CDPCFG_PIN_OLED_RESET 16
+
+    // actualy missing
+    #define CDPCFG_PIN_LORA_DIO1 -1
+
+  #else
+    #error "no known board defined"
+  #endif
 
 
-// Baud Rate
-#define CDPCFG_SERIAL_BAUD 115200
 
-// Oled Display settings
-#define CDPCFG_PIN_OLED_CLOCK 15
-#define CDPCFG_PIN_OLED_DATA   4
-#define CDPCFG_PIN_OLED_RESET 16
+  // non BOARD-specific config
 
-
-// Acces point IP adress
-#define CDPCFG_AP_IP1 192
-#define CDPCFG_AP_IP2 168
-#define CDPCFG_AP_IP3 1
-#define CDPCFG_AP_IP4 1
+  // Username and Password for OTA web page
+  #define CDPCFG_UPDATE_USERNAME "username"
+  #define CDPCFG_UPDATE_PASSWORD "password"
 
 
-// Asyncwebserver Port
-#define CDPCFG_WEB_PORT 80
+  // Serial Console Baud Rate
+  #define CDPCFG_SERIAL_BAUD 115200
 
 
-//Lora configurations
-#define CDPCFG_PIN_LORA_CS   18
-#define CDPCFG_PIN_LORA_DIO0 26
-#define CDPCFG_PIN_LORA_DIO1 25
-#define CDPCFG_PIN_LORA_RST  14
+  // Access point IP adress
+  #define CDPCFG_AP_IP1 192
+  #define CDPCFG_AP_IP2 168
+  #define CDPCFG_AP_IP3 1
+  #define CDPCFG_AP_IP4 1
 
 
-#define CDPCFG_RF_LORA_FREQ  915.0
-#define CDPCFG_RF_LORA_BW    125.0
-#define CDPCFG_RF_LORA_SF      7
-#define CDPCFG_RF_LORA_TXPOW  20
-#define CDPCFG_RF_LORA_GAIN    0
+  // Asyncwebserver Port
+  #define CDPCFG_WEB_PORT 80
+
+  // Lora RF configuration
+  #define CDPCFG_RF_LORA_FREQ  915.0
+  #define CDPCFG_RF_LORA_BW    125.0
+  #define CDPCFG_RF_LORA_SF      7
+  #define CDPCFG_RF_LORA_TXPOW  20
+  #define CDPCFG_RF_LORA_GAIN    0
+
+  // cdp configuration
+  #define CDPCFG_CDP_BUFSIZE 250
+  #define CDPCFG_UUID_LEN 8
+
+  // Timer in milliseconds
+  #define CDPCFG_MILLIS_ALIVE   1800000
+  #define CDPCFG_MILLIS_REBOOT 43200000
 
 
-#define CDPCFG_PIN_LED1 25
-
-
-#define CDPCFG_CDP_BUFSIZE 250
-
-//Timer in milliseconds
-#define CDPCFG_MILLIS_ALIVE   1800000
-#define CDPCFG_MILLIS_REBOOT 43200000
-
-//length of the uuid
-#define CDPCFG_UUID_LEN 8
-
-
-//Led Pins
-#define CDPCFG_PIN_RGBLED_R 25
-#define CDPCFG_PIN_RGBLED_G  4
-#define CDPCFG_PIN_RGBLED_B  2
-
+  // RGB Led Pins
+  #define CDPCFG_PIN_RGBLED_R 25
+  #define CDPCFG_PIN_RGBLED_G  4
+  #define CDPCFG_PIN_RGBLED_B  2
 
 
 #endif // CDPCFG
@@ -94,4 +114,6 @@
     #include "cdpcfg-post.h"
   #endif
 #endif
+
+
 

--- a/library.json
+++ b/library.json
@@ -30,7 +30,6 @@
         "[Ee]xamples/*/*.ino"
     ],
     "dependencies": {
-        "LoRa": "~0.7.1",
         "U8g2": "~2.28.0",
         "arduino-timer": "~2.0.1",
         "ESP Async WebServer": "~1.2.3",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ClusterDuck
-version=1.1.6
+version=1.1.7
 author=Project OWL <info@project-owl.com>
 maintainer=Project OWL <info@project-owl.com>
 sentence=Mesh communication protocol.


### PR DESCRIPTION
bulk PR of minor things that piled up here in the last days:

* bdd54d5 is the lora-dumper compatible debugprinting of lora pkts. 
* * the tohex helper function is needed because arduino String(blah,HEX) doesnt add a leading 0 so there would be need for a helper-function that checks each byte for being >15 and adding a 0 if not anyways.
* * i prefer a "clean" function over a "workaround for builtin" one in this case.
* * it uses the arduino String function for the result but avoids memory reallocation/fragmentation by pre-allocating the output string. (which is easy since we know exactly how many chars we are going to need from the start)

* 18267ca adds and documents two ways for overriding all or parts of cdpcfg

* 2f7f206 moves around config defines to separate all pin/hardware related ones into one block
* * the diff looks uglier than the result in this case since it also changes indenting, so basicly the diff is "everything changed".

* e6ae91c adds a second board definition (for a non-tbeam ttgo board) to the board-specific-config mechanism introduced in the last commit.

* 56121f9 removes LoRa from list of required libs (since we are using RadioLib now) and bump the version number while i am touching the pio config

full set of commits tested with PIO build of TelemetryDuck (==mama) on both supported boards.