### PR TITLE
Possible fix for issue # 115 "papaduck example mqtt size off by one char"

### DIFF
--- a/examples/PapaDuckExample/PapaDuckExample.ino
+++ b/examples/PapaDuckExample/PapaDuckExample.ino
@@ -109,7 +109,7 @@ void quackJson() {
 
   String loc = "iot-2/evt/"+ lastPacket.topic +"/fmt/json";
   Serial.print(loc);
-  int len = loc.length();
+  int len = loc.length() + 1;
 
   char topic[len];
   loc.toCharArray(topic, len);

--- a/examples/PapaDuckExample/PapaDuckExample.ino
+++ b/examples/PapaDuckExample/PapaDuckExample.ino
@@ -109,6 +109,7 @@ void quackJson() {
 
   String loc = "iot-2/evt/"+ lastPacket.topic +"/fmt/json";
   Serial.print(loc);
+  // add space for null char
   int len = loc.length() + 1;
 
   char topic[len];


### PR DESCRIPTION
Just added space for the null char in the topic.
Changed line number 112 from 
int len = loc.length();

to

to int len = loc(length() + 1);