### PR TITLE
Fixes mana duck message relay issue

### DIFF
--- a/src/ClusterDuck.h
+++ b/src/ClusterDuck.h
@@ -112,7 +112,6 @@ public:
   void setupLED();
 
 protected:
-  static Packet _lastPacket;
   String _deviceId = "";
   DuckDisplay* _duckDisplay = DuckDisplay::getInstance();
   DuckLed* _duckLed = DuckLed::getInstance();


### PR DESCRIPTION
When testing with a full cluster `LINK -> MAMA -> PAPA ---> (DMS)` The Link messages where not being relayed by the mama duck. Instead an empty message was sent.

The issue was the `_lastPacket` global variable was still defined in _ClusterDuck.cpp_ and was used when sending the payload, instead of the `_lastePacket` now defined in the DuckLora component.

This did cause some other side effects in DMS (e.g empty/rogue message, incorrect paths, etc..)

I tested with a full cluster and it working now. Also tested the Portal message, it is now correctly received and shown in DMS.
