### PR TITLE
src: remove unnecessary variable in DuckRadio

### DIFF
--- a/src/DuckRadio.cpp
+++ b/src/DuckRadio.cpp
@@ -83,8 +83,8 @@ int DuckRadio::setupRadio(LoraConfigParams config) {
   lora.setDio0Action(config.func);
 
   // set sync word to private network
-  err = lora.setSyncWord(0x12);
-  if (err != ERR_NONE) {
+  rc = lora.setSyncWord(0x12);
+  if (rc != ERR_NONE) {
     logerr("ERROR  sync word is invalid");
     return DUCKLORA_ERR_SETUP;
   }

--- a/src/include/DuckRadio.h
+++ b/src/include/DuckRadio.h
@@ -170,7 +170,6 @@ private:
   DuckRadio& operator=(DuckRadio const&) = delete;
   static DuckRadio* instance;
   DuckDisplay* display = DuckDisplay::getInstance();
-  int err;
 };
 
 #endif


### PR DESCRIPTION
use local rc variable in DuckRadio::setupRadio and remove unused err
declaration in DuckRadio.h

Fixes: https://github.com/Call-for-Code/ClusterDuck-Protocol/issues/223

Signed-off-by: faradaym <rcheyenne.truss@gmail.com>