### PR TITLE
Dependency Script Revisions

### DIFF
--- a/cdp-dependency-automator-script/dependencies.json
+++ b/cdp-dependency-automator-script/dependencies.json
@@ -28,8 +28,8 @@
     "url": "https://github.com/knolleary/pubsubclient/archive/refs/tags/v2.8.zip"
   },
   "RadioLib" : {
-    "version": "5.6.0",
-    "url": "https://github.com/jgromes/RadioLib/archive/refs/tags/5.6.0.zip"
+    "version": "6.3.0",
+    "url": "https://github.com/jgromes/RadioLib/archive/refs/tags/6.3.0.zip"
   },
   "U8g2": {
     "version": "2.33.2",

--- a/cdp-dependency-automator-script/dependencies.json
+++ b/cdp-dependency-automator-script/dependencies.json
@@ -1,23 +1,19 @@
 {
-  "arduino-timer": {
-    "version": "3.0.0",
-    "url": "https://github.com/contrem/arduino-timer/archive/refs/heads/master.zip"
-  },
-  "U8g2": {
-    "version": "2.33.2",
-    "url": "https://downloads.arduino.cc/libraries/github.com/olikraus/U8g2-2.33.15.zip"
-  },
   "ArduinoJson" : {
     "version": "6.21.0",
     "url": "https://github.com/bblanchon/ArduinoJson/releases/download/v6.21.0/ArduinoJson-v6.21.0.h"
   },
+  "arduino-timer": {
+    "version": "3.0.0",
+    "url": "https://github.com/contrem/arduino-timer/archive/refs/heads/master.zip"
+  },
+  "AsyncTCP" : {
+    "version": "1.1.1",
+    "url": "https://github.com/me-no-dev/AsyncTCP/archive/refs/heads/master.zip"
+  },
   "CRC32" : {
     "version": "2.33.2",
     "url": "https://github.com/bakercp/CRC32/archive/refs/tags/2.0.0.zip"
-  },
-  "RadioLib" : {
-    "version": "5.6.0",
-    "url": "https://github.com/jgromes/RadioLib/archive/refs/tags/5.6.0.zip"
   },
   "Crypto" : {
     "version": "0.4.0",
@@ -27,12 +23,16 @@
     "version": "1.2.3",
     "url": "https://github.com/me-no-dev/ESPAsyncWebServer/archive/refs/heads/master.zip"
   },
-  "AsyncTCP" : {
-    "version": "1.1.1",
-    "url": "https://github.com/me-no-dev/AsyncTCP/archive/refs/heads/master.zip"
-  },
   "pubsubclient" : {
     "version": "2.8",
     "url": "https://github.com/knolleary/pubsubclient/archive/refs/tags/v2.8.zip"
+  },
+  "RadioLib" : {
+    "version": "5.6.0",
+    "url": "https://github.com/jgromes/RadioLib/archive/refs/tags/5.6.0.zip"
+  },
+  "U8g2": {
+    "version": "2.33.2",
+    "url": "https://downloads.arduino.cc/libraries/github.com/olikraus/U8g2-2.33.15.zip"
   }
 }

--- a/cdp-dependency-automator-script/dependencies.json
+++ b/cdp-dependency-automator-script/dependencies.json
@@ -28,8 +28,8 @@
     "url": "https://github.com/knolleary/pubsubclient/archive/refs/tags/v2.8.zip"
   },
   "RadioLib" : {
-    "version": "6.3.0",
-    "url": "https://github.com/jgromes/RadioLib/archive/refs/tags/6.3.0.zip"
+    "version": "5.6.0",
+    "url": "https://github.com/jgromes/RadioLib/archive/refs/tags/5.6.0.zip"
   },
   "U8g2": {
     "version": "2.33.2",

--- a/cdp-dependency-automator-script/install-dependencies.py
+++ b/cdp-dependency-automator-script/install-dependencies.py
@@ -45,7 +45,11 @@ def install(dep_file_name, destination):
                 if response.status_code == 200:
                     content_type = response.headers.get('Content-Type')
                     if content_type == 'application/zip':
-                        file_path = os.path.join(destination, dependency)
+                        zip_dir = os.path.join(destination, dependency)
+                        if not os.path.exists(zip_dir):
+                            os.makedirs(zip_dir)
+
+                        file_path = os.path.join(destination, f"{dependency}.zip")
 
                         with open(file_path, 'wb') as file:
                             file.write(response.content)

--- a/cdp-dependency-automator-script/install-dependencies.py
+++ b/cdp-dependency-automator-script/install-dependencies.py
@@ -31,7 +31,7 @@ def run():
             print("Please respond with 'yes' or 'no'")
 
 
-def install(dep_file_name, destination): #update to use brentons dep version
+def install(dep_file_name, destination):
     retry_count = 0
     json_file = open(dep_file_name)
     dependencies = json.load(json_file)

--- a/cdp-dependency-automator-script/install-dependencies.py
+++ b/cdp-dependency-automator-script/install-dependencies.py
@@ -1,61 +1,88 @@
+#!/usr/bin/python3
 import os
 import requests
 import json
 import zipfile
+import sys
 
-retry_count = 0
-json_file = open('dependencies.json')
-dependencies = json.load(json_file)
+def run():
+    destination = os.path.dirname(__file__)
+    while os.path.basename(destination) != 'libraries':
+        destination = os.path.dirname(destination)
 
-absolute_path = os.path.dirname(__file__)
-destination = absolute_path
-while os.path.basename(destination) != 'libraries':
-    destination = os.path.dirname(destination)
+    if not os.path.exists(destination):
+        os.makedirs(destination)
 
-if not os.path.exists(destination):
-    os.makedirs(destination)
+    print(f"installing basic CDP dependencies in {destination}")
+    install('dependencies.json', destination)
 
-for dependency, info in dependencies.items():
-    MAX_RETRIES = 5
-    while retry_count < 5:
-        try:
-            response = requests.get(info["url"])
+    prompting = True
+    while prompting:
+        print(f"install optional dependencies for sensors, gps, etc? (Y)es/(N)o")
+        choice = input().lower()
+        if choice == '' or choice in ["yes", "ye", "y"]:
+            install('optional-dependencies.json', destination)
+            print("Installation complete.")
+            prompting = False
+        elif choice in ["no", "n"]:
+            prompting = False
+            print("Installation complete.")
+        else:
+            print("Please respond with 'yes' or 'no'")
 
-            if response.status_code == 200:
-                content_type = response.headers.get('Content-Type')
-                if content_type == 'application/zip':
-                    file_path = os.path.join(destination, dependency)
 
-                    with open(file_path, 'wb') as file:
-                        file.write(response.content)
+def install(dep_file_name, destination): #update to use brentons dep version
+    retry_count = 0
+    json_file = open(dep_file_name)
+    dependencies = json.load(json_file)
 
-                    print(f"{dependency} successfully downloaded.")
+    for dependency, info in dependencies.items():
+        MAX_RETRIES = 5
+        while retry_count < 5:
+            try:
+                response = requests.get(info["url"])
 
-                    print(f"Unzipping...")
-                    with zipfile.ZipFile(file_path, 'r') as zip_ref:
-                        zip_ref.extractall(destination)
+                if response.status_code == 200:
+                    content_type = response.headers.get('Content-Type')
+                    if content_type == 'application/zip':
+                        file_path = os.path.join(destination, dependency)
 
-                    os.remove(file_path)
+                        with open(file_path, 'wb') as file:
+                            file.write(response.content)
 
-                elif content_type == 'application/octet-stream':
-                    file_path = os.path.join(destination, dependency)
-                    if not os.path.exists(file_path):
-                        os.makedirs(file_path)
+                        print(f"{dependency} v{info['version']} successfully downloaded.")
 
-                    with open(os.path.join(file_path, dependency) + ".h", 'wb') as file:
-                        file.write(response.content)
+                        print(f"Unzipping...")
+                        with zipfile.ZipFile(file_path, 'r') as zip_ref:
+                            zip_ref.extractall(destination)
 
-                    print(f"{dependency} successfully downloaded.")
+                        os.remove(file_path)
 
-                else:
-                    print(f"{dependency} -- unsupported content type: {content_type}")
+                    elif content_type == 'application/octet-stream':
+                        file_path = os.path.join(destination, dependency)
+                        if not os.path.exists(file_path):
+                            os.makedirs(file_path)
 
-            break
+                        with open(os.path.join(file_path, dependency) + ".h", 'wb') as file:
+                            file.write(response.content)
 
-        except requests.exceptions.RequestException as e:
-            print(f"Error downloading {dependency}: {e}")
-            retry_count += 1
-            if retry_count == MAX_RETRIES:
-                print(f"Failed to download {dependency}.")
-                retry_count = 0
+                        print(f"{dependency} successfully downloaded.")
+
+                    else:
+                        print(f"{dependency} -- unsupported content type: {content_type}")
+
                 break
+
+            except requests.exceptions.RequestException as e:
+                print(f"Error downloading {dependency}: {e}")
+                retry_count += 1
+                if retry_count == MAX_RETRIES:
+                    print(f"Failed to download {dependency}.")
+                    retry_count = 0
+                    break
+
+#enforce use of python 3
+if sys.version_info[0] < 3:
+   print(f"Script requires python 3 -- your version: {sys.version_info[0]}")
+else:
+    run()

--- a/cdp-dependency-automator-script/optional-dependencies.json
+++ b/cdp-dependency-automator-script/optional-dependencies.json
@@ -1,0 +1,46 @@
+{
+  "Adafruit_BMP085_Unified" : {
+    "version": "1.1.3",
+    "url": "https://github.com/adafruit/Adafruit_BMP085_Unified/archive/refs/tags/1.1.3.zip"
+  },
+  "Adafruit_BMP280_Library" : {
+    "version": "2.6.8",
+    "url": "https://github.com/adafruit/Adafruit_BMP280_Library/archive/refs/tags/2.6.8.zip"
+  },
+  "Adafruit_BusIO" : {
+    "version": "1.14.5",
+    "url": "https://github.com/adafruit/Adafruit_BusIO/archive/refs/tags/1.14.5.zip"
+  },
+  "Adafruit_Unified_Sensor" : {
+    "version": "1.1.14",
+    "url": "https://downloads.arduino.cc/libraries/github.com/adafruit/Adafruit_Unified_Sensor-1.1.14.zip"
+  },
+  "AXP202X_Library": {
+    "version": "1.1.3",
+    "url": "https://github.com/lewisxhe/AXP202X_Library/archive/refs/tags/V1.1.3.zip"
+  },
+  "DHT-sensor-library" : {
+    "version": "1.4.6",
+    "url": "https://downloads.arduino.cc/libraries/github.com/adafruit/DHT_sensor_library-1.4.6.zip"
+  },
+  "FastLED" : {
+    "version": "3.6.0",
+    "url": "https://github.com/FastLED/FastLED/archive/refs/tags/3.6.0.zip"
+  },
+  "GP2YDustSensor" : {
+    "version": "1.1.0",
+    "url": "https://github.com/luciansabo/GP2YDustSensor/archive/refs/tags/v1.1.0.zip"
+  },
+  "IridiumSBD" : {
+    "version": "2.0",
+    "url": "https://github.com/mikalhart/IridiumSBD/archive/refs/tags/v2.0.0.zip"
+  },
+  "MQSensorsLib" : {
+    "version": "3.0.0",
+    "url": "https://github.com/miguel5612/MQSensorsLib/archive/refs/tags/v3.0.0.zip"
+  },
+  "TinyGPSPlus" : {
+    "version": "1.0.3a",
+    "url": "https://github.com/mikalhart/TinyGPSPlus/archive/refs/tags/v1.0.3a.zip"
+  }
+}


### PR DESCRIPTION
Updating to include optional dependencies as well as a few other changes suggested by @dmandala

**Is this a patch, a minor version change, or a major version change**
Patch

**Testing Methodology. How can someone test your pull request?** 
1. cd into the project-root/cdp-dependency-automator-script
2. run the python script
3. compile any basic Duck example ino with the basic dependencies
4. compile all other examples when optional dependencies were installed

**Does the CDP Wiki need to be updated?**
[This page in the Wiki](https://github.com/Call-for-Code/ClusterDuck-Protocol/wiki/Linux-CDP-Dev-Setup) appears to be outdated from before the introduction of the python script

**Additional context**
We were discussing the possibility of putting this script in it's own repository and adding CDP to the dependencies, and I can make those changes in the future if we go that route.

