### PR TITLE
adding gps pins for sx1262

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@
 
 ;   default_envs = heltec_wifi_lora_32_V3
 ;  default_envs = heltec_wifi_lora_32_V2
-  default_envs = lilygo_t_beam_sx1262
+   default_envs = lilygo_t_beam_sx1262
 ;  default_envs = cubecell_gps
 ;  default_envs = cubecell_board_v2
 ;   default_envs = ttgo_lora32_v1
@@ -130,6 +130,9 @@
     ${env:esp32_base.lib_deps}
     mikalhart/TinyGPSPlus @ ~1.0.2
     lewisxhe/XPowersLib@^0.1.5
+  build_flags =
+    ${env.build_flags}
+
 [env:cubecell_gps]
   ; extends cubecell_base environment which extends cdp_common environment
   extends = cubecell_base 

--- a/src/include/boards/lilygo_t_beam_sx1262.h
+++ b/src/include/boards/lilygo_t_beam_sx1262.h
@@ -15,6 +15,10 @@
 #define CDPCFG_BAT_MULDIV 200 / 100 
 #define CDPCFG_PIN_LED1 25
 
+//GPS configuration
+#define CDPCFG_GPS_RX 34
+#define CDPCFG_GPS_TX 12
+
 // LoRa configuration
 #define CDPCFG_PIN_LORA_CS      18
 #define CDPCFG_PIN_LORA_RST     23


### PR DESCRIPTION
**What is is PR for?**

- [x] Code update
- [ ] Documentation update
- [ ] Infrastructure update

**What does this PR do?**  
This is a hotfix for something I thought was already in #312

**Is this related to an open issue?**  
Not a currently open issue, but the old one linked to #312

**Testing methodology**  
Just flash code to a sx1262 board that instantiates the gps object like so:
`DuckGPS gps;`

It should take the default pins that are in this PR.

**Additional context**  
These default pins are already in the sx1276 board profile, but the pins are the same on the sx1262 and weren't added.

**Checklist**
Before you submit this pull request, please make sure you have done the following:

_General_  

- [x] Contribution Guidelines: Have you read the contribution guidelines?
- [x] Code of Conduct: Have you read the code of conduct?
- [ ] Documentation: If applicable, have you added or updated all relevant documentation?

_For Code Updates_  

- [x] Hardware Validation: If relevant, have you validated your changes on actual supported Duck hardware?
- [ ] Unit Tests: Have you run the unit tests on the device?
- [ ] Network Testing: If applicable, have you tested your changes on a Duck network?
- [ ] Licensing: Have you added a copyright and license header to each new file?

_Tested Targets (Please check all that apply)_

- [ ] All
- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] Heltec CubeCell Series
- [x] TTGO T-Beam (SX1262)
- [ ] Others
