### PR TITLE
Switch to PlatformIO CLI In CI Build

### DIFF
--- a/.github/workflows/arduino_ci.yml
+++ b/.github/workflows/arduino_ci.yml
@@ -42,41 +42,10 @@ jobs:
       run: |
         cppcheck --version
         cppcheck --error-exitcode=1 --std=c++2a --force src
-
-    # - name: Arduino setup
-    #   run: |
-    #     # Temporarily enable debug output
-    #     set -x
-    #     arduino-cli config init
-    #     arduino-cli config set library.enable_unsafe_install true
-    #     echo "[ARDUINO SETUP] Updating the index to include the Heltec ESP32 boards"
-    #     arduino-cli core update-index --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
-        
-    #     # install the Heltec ESP32 boards
-    #     if [[ "${{ matrix.board }}" =~ "esp32:esp32:" ]]; then
-    #       echo "[ARDUINO SETUP] Installing the Heltec ESP32 board"
-    #       arduino-cli core install esp32:esp32@3.3.3 --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
-    #     fi
-
-    # - name: Install CDP
-    #   run: |
-    #     echo "Syncing files..."
-    #     rsync -rltv --exclude=.git --exclude=bin  --exclude=docs --exclude=3D-Print-Files ${PWD}/ /tmp/CDP/ > /dev/null
-
-    #     echo "Creating zip..."
-    #     (cd /tmp && zip -r /tmp/cdp.zip CDP > /dev/null)
-
-    #     echo "Installing CDP..."
-    #     arduino-cli lib install --zip-path /tmp/cdp.zip        
-
-    #     echo "CDP Installed."
-    #     echo
-    #     arduino-cli lib list    
-
     - name: Install CDP dependencies
       run: |
         echo "Installing dependencies..."
-        platformio lib install
+        platformio pkg install
     # - name: Unit Tests
     #   run: |
     #     python -m pip install platformio
@@ -90,7 +59,6 @@ jobs:
       if: startsWith(github.ref, 'refs/heads/release')
       run: |
         EXAMPLE_DIR=Basic-Ducks/PapaDuck platformio run -e local_lilygo_t_beam_sx1262
-        pio lib install "https://github.com/FastLED/FastLED.git"
         EXAMPLE_DIR=Basic-Ducks/DetectorDuck platformio run -e local_lilygo_t_beam_sx1262
     - name: Arduino Registry Lint
       if: startsWith(github.ref, 'refs/heads/release')

--- a/.github/workflows/arduino_ci.yml
+++ b/.github/workflows/arduino_ci.yml
@@ -56,7 +56,7 @@ jobs:
         # install the Heltec ESP32 boards
         if [[ "${{ matrix.board }}" =~ "esp32:esp32:" ]]; then
           echo "[ARDUINO SETUP] Installing the Heltec ESP32 board"
-          arduino-cli core install esp32:esp32@3.2.0 --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
+          arduino-cli core install esp32:esp32@3.3.4 --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
         fi
 
     - name: Install CDP

--- a/.github/workflows/arduino_ci.yml
+++ b/.github/workflows/arduino_ci.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        board: ["esp32:esp32:heltec_wifi_lora_32_V3"]
 
     steps:
     - name: Checkout code
@@ -37,6 +35,7 @@ jobs:
         sudo apt-get -y install cppcheck
         python -m pip install pyserial
         curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s
+        python -m pip install platformio
         echo "$PWD/bin/" >> $GITHUB_PATH
 
     - name: Run cppcheck
@@ -44,88 +43,55 @@ jobs:
         cppcheck --version
         cppcheck --error-exitcode=1 --std=c++2a --force src
 
-    - name: Arduino setup
-      run: |
-        # Temporarily enable debug output
-        set -x
-        arduino-cli config init
-        arduino-cli config set library.enable_unsafe_install true
-        echo "[ARDUINO SETUP] Updating the index to include the Heltec ESP32 boards"
-        arduino-cli core update-index --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
+    # - name: Arduino setup
+    #   run: |
+    #     # Temporarily enable debug output
+    #     set -x
+    #     arduino-cli config init
+    #     arduino-cli config set library.enable_unsafe_install true
+    #     echo "[ARDUINO SETUP] Updating the index to include the Heltec ESP32 boards"
+    #     arduino-cli core update-index --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
         
-        # install the Heltec ESP32 boards
-        if [[ "${{ matrix.board }}" =~ "esp32:esp32:" ]]; then
-          echo "[ARDUINO SETUP] Installing the Heltec ESP32 board"
-          arduino-cli core install esp32:esp32@3.3.3 --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
-        fi
+    #     # install the Heltec ESP32 boards
+    #     if [[ "${{ matrix.board }}" =~ "esp32:esp32:" ]]; then
+    #       echo "[ARDUINO SETUP] Installing the Heltec ESP32 board"
+    #       arduino-cli core install esp32:esp32@3.3.3 --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
+    #     fi
 
-    - name: Install CDP
-      run: |
-        echo "Syncing files..."
-        rsync -rltv --exclude=.git --exclude=bin  --exclude=docs --exclude=3D-Print-Files ${PWD}/ /tmp/CDP/ > /dev/null
+    # - name: Install CDP
+    #   run: |
+    #     echo "Syncing files..."
+    #     rsync -rltv --exclude=.git --exclude=bin  --exclude=docs --exclude=3D-Print-Files ${PWD}/ /tmp/CDP/ > /dev/null
 
-        echo "Creating zip..."
-        (cd /tmp && zip -r /tmp/cdp.zip CDP > /dev/null)
+    #     echo "Creating zip..."
+    #     (cd /tmp && zip -r /tmp/cdp.zip CDP > /dev/null)
 
-        echo "Installing CDP..."
-        arduino-cli lib install --zip-path /tmp/cdp.zip        
+    #     echo "Installing CDP..."
+    #     arduino-cli lib install --zip-path /tmp/cdp.zip        
 
-        echo "CDP Installed."
-        echo
-        arduino-cli lib list    
+    #     echo "CDP Installed."
+    #     echo
+    #     arduino-cli lib list    
 
     - name: Install CDP dependencies
       run: |
         echo "Installing dependencies..."
-        file="library.properties"
-        dependsvar=$(awk -F'=' '/depends/{print $2}' $file)
-
-        # read the array from the string
-        IFS=',' read -r -a dependencies <<< "$dependsvar"
-
-        for dep in "${dependencies[@]}"
-        do
-          echo "Installing $dep..."
-          if [[ "$dep" == *"github"* ]]; then
-            arduino-cli lib install --git-url "$dep" 
-          elif [[ "$dep" == *".zip"* ]]; then
-            arduino-cli lib install --zip-path "$dep"
-          else
-            arduino-cli lib install "$dep"
-          fi
-        done
-        echo "Dependencies installed successfully!"
-        echo
-        arduino-cli lib list
+        platformio lib install
     # - name: Unit Tests
     #   run: |
     #     python -m pip install platformio
     #     platformio run --target upload --environment test_heltec_wifi_lora_32_V3
     - name: Build
       run: |
-        echo "List of installed Arduino Cores:"
-        arduino-cli core list
-        buildExampleSketch() { 
-          BOARD=${{ matrix.board }}
-          echo "Building $1/$2/$2.ino..."
-          arduino-cli compile -v -t -b ${{ matrix.board }} --build-property compiler.cpp.extra_flags=-std=c++2a $PWD/examples/$1/$2/$2.ino > ${BOARD##*:}-$2-build.log 2>&1; 
-          echo "Build complete."
-        } 
-        buildExampleSketch Basic-Ducks DuckLink
-        buildExampleSketch Basic-Ducks MamaDuck
+        echo "Building project..."
+        EXAMPLE_DIR=Basic-Ducks/DuckLink platformio run -e local_lilygo_t_beam_sx1262
+        EXAMPLE_DIR=Basic-Ducks/MamaDuck platformio run -e local_lilygo_t_beam_sx1262
     - name: Release Build
       if: startsWith(github.ref, 'refs/heads/release')
       run: |
-        buildExampleSketch() { 
-          BOARD=${{ matrix.board }}
-          echo "Building $1/$2/$2.ino..."
-          arduino-cli compile -v -t -b ${{ matrix.board }} --build-property compiler.cpp.extra_flags=-std=c++2a $PWD/examples/$1/$2/$2.ino > ${BOARD##*:}-$2-build.log 2>&1; 
-          echo "Build complete."
-        } 
-        buildExampleSketch Basic-Ducks PapaDuck
-        arduino-cli lib install --git-url "https://github.com/FastLED/FastLED.git"
-        buildExampleSketch Basic-Ducks DetectorDuck
-        buildExampleSketch Custom-Mama-Examples Custom-Mama-Example
+        EXAMPLE_DIR=Basic-Ducks/PapaDuck platformio run -e local_lilygo_t_beam_sx1262
+        pio lib install "https://github.com/FastLED/FastLED.git"
+        EXAMPLE_DIR=Basic-Ducks/DetectorDuck platformio run -e local_lilygo_t_beam_sx1262
     - name: Arduino Registry Lint
       if: startsWith(github.ref, 'refs/heads/release')
       uses: arduino/arduino-lint-action@v2

--- a/.github/workflows/arduino_ci.yml
+++ b/.github/workflows/arduino_ci.yml
@@ -56,7 +56,7 @@ jobs:
         # install the Heltec ESP32 boards
         if [[ "${{ matrix.board }}" =~ "esp32:esp32:" ]]; then
           echo "[ARDUINO SETUP] Installing the Heltec ESP32 board"
-          arduino-cli core install esp32:esp32@3.2.0[] --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
+          arduino-cli core install esp32:esp32@3.2.0 --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
         fi
 
     - name: Install CDP

--- a/.github/workflows/arduino_ci.yml
+++ b/.github/workflows/arduino_ci.yml
@@ -56,7 +56,7 @@ jobs:
         # install the Heltec ESP32 boards
         if [[ "${{ matrix.board }}" =~ "esp32:esp32:" ]]; then
           echo "[ARDUINO SETUP] Installing the Heltec ESP32 board"
-          arduino-cli core install esp32:esp32@3.3.4 --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
+          arduino-cli core install esp32:esp32@3.3.3 --additional-urls https://github.com/Heltec-Aaron-Lee/WiFi_Kit_series/releases/download/3.0.0/package_heltec_esp32_index.json
         fi
 
     - name: Install CDP

--- a/examples/Basic-Ducks/DetectorDuck/platformio.ini
+++ b/examples/Basic-Ducks/DetectorDuck/platformio.ini
@@ -32,14 +32,12 @@
     extends = esp32_base
     lib_deps = 
       ${cdp_common.lib_deps}
-      FastLED/FastLED@^3.6.0
       https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/archive/refs/tags/4.4.0.zip
         
   [env:local_cdp]
     extends = esp32_base
     lib_deps = 
       ${cdp_common.lib_deps}
-      FastLED/FastLED@^3.6.0
       symlink://../../../
 
       ; -------------------------------------------------------------------------------------------------------      

--- a/library.json
+++ b/library.json
@@ -38,6 +38,7 @@
         "jgromes/RadioLib": "^7.1.2",
         "mathieucarbou/ESP Async WebServer": "^2.7.0",
         "knolleary/PubSubClient":"^2.8",
-        "mikalhart/TinyGPSPlus": "~1.0.2"
+        "mikalhart/TinyGPSPlus": "~1.0.2",
+        "FastLED /FastLED": "^3.10.3"
     }
 }

--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=The ClusterDuck Protocol is an open-source project under The Linux Fou
 category=Communication
 url=https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol
 architectures=*
-depends=arduino-timer,U8g2,ArduinoJson,CRC32,RadioLib,Async TCP,ESP Async WebServer,PubSubClient,TinyGPSPlus
+depends=arduino-timer,U8g2,ArduinoJson,CRC32,RadioLib,Async TCP,ESP Async WebServer,PubSubClient,TinyGPSPlus,FastLED
 includes=CDP.h

--- a/src/CDP.h
+++ b/src/CDP.h
@@ -13,16 +13,16 @@
 #include "cdp_external_board.h"
 #endif
 
-#include "cdpcfg.h"
-#include "../Ducks/DetectorDuck.h"
-#include "../Ducks/DuckLink.h"
-#include "../Ducks/MamaDuck.h"
-#include "../Ducks/PapaDuck.h"
-#include "../utils/MemoryFree.h"
-#include "../CdpPacket.h"
-#include "../utils/DuckError.h"
-#include "../utils/DuckLogger.h"
-#include "../wifi/DuckWifi.h"
+#include "./include/cdpcfg.h"
+#include "./Ducks/DetectorDuck.h"
+#include "./Ducks/DuckLink.h"
+#include "./Ducks/MamaDuck.h"
+#include "./Ducks/PapaDuck.h"
+#include "./utils/MemoryFree.h"
+#include "./CdpPacket.h"
+#include "./utils/DuckError.h"
+#include "./utils/DuckLogger.h"
+#include "./wifi/DuckWifi.h"
 #define CDP_STRINGIFY(x) #x
 #define CDP_VALUE(x) CDP_STRINGIFY(x)
 

--- a/src/routing/bloomfilter.h
+++ b/src/routing/bloomfilter.h
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <math.h>
 #include <memory>
-#include <../CdpPacket.h>
+#include "../CdpPacket.h"
 
 
 const int DEFAULT_NUM_SECTORS = 312; 


### PR DESCRIPTION
**Affected Areas:**

- [x] Code
- [ ] Documentation
- [x] Infrastructure

**Description:**  
Updates the CI build to use platformIO cli instead of arduino Core ESP32. PlatformIO does not keep up with the latest espidf -- causing some issues when updating Arduino Core which does keep up to date. Arduino Core needs to be updated to v3.x in order to use C++ 20, which is the new enforced standard for CDP. 

This PR also adds FastLED to the base dependencies.

**Related Issues:**  
#377 

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
