### PR TITLE
DuckLogger changes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ extra_scripts = pre:tools/example_select.py
   src_dir = ./examples/Basic-Ducks/MamaDuck
 
 ; uncomment the line below to build for your board
-   
+
 ;   default_envs = local_lilygo_t_beam_supreme_sx1262
 ;   default_envs = local_heltec_wifi_lora_32_V2
 ;   default_envs = local_lilygo_t_beam_sx1276
@@ -128,11 +128,19 @@ extra_scripts = pre:tools/example_select.py
 [env:local_heltec_wifi_lora_32_V3]
   extends = env:local_cdp
   board = heltec_wifi_lora_32_V3
+  build_flags =
+    ${esp32_base.build_flags}
+    -DBOARD_HAS_PSRAM
+    -DCDP_DEBUG
 
 ; LOCAL LILYGO_T_BEAM_SX1262
 [env:local_lilygo_t_beam_sx1262]
   extends = env:local_cdp
   board = ttgo-t-beam
+  build_flags =
+    ${esp32_base.build_flags}
+    -DBOARD_HAS_PSRAM
+    -DCDP_DEBUG
 
 ; LOCAL LILYGO_T_BEAM_SUPREME_SX1262
 [env:local_lilygo_t_beam_supreme_sx1262]
@@ -144,6 +152,7 @@ extra_scripts = pre:tools/example_select.py
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DBOARD_HAS_PSRAM
+    -DCDP_DEBUG
   upload_speed = 921600
   monitor_speed = 115200
 
@@ -151,6 +160,9 @@ extra_scripts = pre:tools/example_select.py
 [env:local_lilygo_t_beam_sx1276]
   extends = env:local_cdp
   board = ttgo-lora32-v1
+  build_flags =
+    ${esp32_base.build_flags}
+    -DCDP_DEBUG
 
 
 
@@ -162,6 +174,7 @@ extra_scripts = pre:tools/example_select.py
   build_flags =
     ${env:cdp_common.build_flags}
     -DTTGO_1_3
+    -DCDP_DEBUG
 
 
 

--- a/src/utils/DuckLogger.h
+++ b/src/utils/DuckLogger.h
@@ -1,11 +1,6 @@
 #ifndef DUCKLOGGER_H
 #define DUCKLOGGER_H
 
-//#ifndef CDP_NO_LOG
-//#include "Arduino.h"
-//#define CDP_DEBUG
-//#endif
-
 
 #ifdef CDP_DEBUG
 #define CDP_LOG_ERROR

--- a/src/utils/DuckLogger.h
+++ b/src/utils/DuckLogger.h
@@ -1,13 +1,10 @@
 #ifndef DUCKLOGGER_H
 #define DUCKLOGGER_H
 
-#ifndef CDP_NO_LOG
-#include "Arduino.h"
-#define CDP_DEBUG
-#endif
-
-
-#define CDP_DEBUG
+//#ifndef CDP_NO_LOG
+//#include "Arduino.h"
+//#define CDP_DEBUG
+//#endif
 
 
 #ifdef CDP_DEBUG
@@ -17,6 +14,21 @@
 #define CDP_LOG_WARN
 #endif
 
+#ifdef CDP_INFO
+#define CDP_LOG_ERROR
+#define CDP_LOG_INFO
+#define CDP_LOG_WARN
+#endif
+
+#ifdef CDP_WARN
+#define CDP_LOG_ERROR
+#define CDP_LOG_WARN
+#endif
+
+#ifdef CDP_ERROR
+#define CDP_LOG_ERROR
+#endif
+
 #ifndef __FILENAME__
 #define __FILENAME__                                                           \
   (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
@@ -24,6 +36,7 @@
 
 
 #if defined(ARDUINO)
+#include "Arduino.h"
 #define OUTPUT_PORT Serial
 #else
 #define PORT std::cout
@@ -54,7 +67,7 @@ static size_t cdpPrintf(const char *format, ...) {
     return len;
 }
 
-#if defined(CDP_LOG_ERROR)
+#ifdef CDP_LOG_ERROR
 #define logerr(format, ...)                                     \
   do {                                                          \
     cdpPrintf("[E]");                                           \
@@ -70,13 +83,13 @@ static size_t cdpPrintf(const char *format, ...) {
   } while (0)
 #else
 #define logerr(format, ...)                                     \
-  {}                                                                            
+  {}
 #define logerr_ln(format, ...)                                  \
   {}
 #endif // CDP_LOG_ERROR
 
 
-#if defined(CDP_LOG_WARN)
+#ifdef CDP_LOG_WARN
 #define logwarn(format, ...)                                    \
   do {                                                          \
     cdpPrintf("[W]");                                           \
@@ -92,7 +105,7 @@ static size_t cdpPrintf(const char *format, ...) {
   } while (0)
 #else
 #define logwarn(format, ...)                                    \
-  {}                                                                            
+  {}
 #define logwarn_ln(format, ...)                                 \
   {}
 #endif // CDP_LOG_WARN
@@ -113,12 +126,12 @@ static size_t cdpPrintf(const char *format, ...) {
   } while (0)
 #else
 #define loginfo(format, ...)                                    \
-  {}                                                                            
+  {}
 #define loginfo_ln(format, ...)                                 \
   {}
 #endif // CDP_LOG_INFO
 
-#if defined(CDP_LOG_DEBUG)
+#ifdef CDP_LOG_DEBUG
 #define logdbg(format, ...)                                     \
   do {                                                          \
     cdpPrintf("[D]");                                           \
@@ -134,7 +147,7 @@ static size_t cdpPrintf(const char *format, ...) {
   } while (0)
 #else
 #define logdbg(format, ...)                                     \
-  {}                                                                            
+  {}
 #define logdbg_ln(format, ...)                                  \
   {}
 #endif


### PR DESCRIPTION
**Affected Areas:**

- [x] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
This is to address #509 and includes changes to the platformio build file to keep current debug behavior while still allowing you to use the log level you want by just changing it in platformio.ini.

**Related Issues:**  

**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [x] Updated relevant documentation
- [x] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [x] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
