### PR TITLE
more expressive errors for packet build failures

### DIFF
--- a/src/Ducks/Duck.h
+++ b/src/Ducks/Duck.h
@@ -439,7 +439,7 @@ class Duck {
         router.getFilter().assignUniqueMessageId(txPacket);
         err = txPacket.prepareForSending();
         if (err != DUCK_ERR_NONE) {
-          logerr_ln("ERROR Failed to build packet, err = " + err);
+          logerr_ln("ERROR Failed to build packet: %s err = %i",getDuckErrorString(err), err);
           return err;
         }
         err = duckRadio.sendData(txPacket.asBytes());
@@ -459,7 +459,7 @@ class Duck {
     int sendToRadio(CdpPacket& txPacket) {
       int err = txPacket.prepareForSending();
       if (err != DUCK_ERR_NONE) {
-        logerr_ln("ERROR Failed to build ping packet, err = " + err);
+        logerr_ln("ERROR Failed to build ping packet: %s, err = %i",getDuckErrorString(err), err);
         return err;
       }
 

--- a/src/utils/DuckError.h
+++ b/src/utils/DuckError.h
@@ -13,8 +13,7 @@ enum DuckError : int {
     /// Invalid argument
     DUCK_ERR_INVALID_ARGUMENT = -5101,
     /// Device Id is too long
-    DUCK_ERR_ID_TOO_LONG = -5101,
-
+    DUCK_ERR_ID_TOO_LONG = -5102,
     /// Lora module initialization error
     DUCKLORA_ERR_BEGIN = -1000,
     /// Lora module configuration error
@@ -86,7 +85,6 @@ inline const char* getDuckErrorString(int error) {
             return "Invalid argument";
         case DUCK_ERR_ID_TOO_LONG:
             return "Device Id is too long";
-
         case DUCKLORA_ERR_BEGIN:
             return "Lora module initialization error";
         case DUCKLORA_ERR_SETUP:

--- a/src/utils/DuckError.h
+++ b/src/utils/DuckError.h
@@ -1,65 +1,150 @@
 #ifndef DUCKERROR_H
 #define DUCKERROR_H
 
+/// Duck error codes enum
+enum DuckError : int {
+    /// No Error
+    DUCK_ERR_NONE = 0,
 
-/// No Error
-#define DUCK_ERR_NONE 0
-// Feature not supported
-#define DUCK_ERR_NOT_SUPPORTED -5000
-// Failed to setup device
-#define DUCK_ERR_SETUP         -5100
+    /// Feature not supported
+    DUCK_ERR_NOT_SUPPORTED = -5000,
+    /// Failed to setup device
+    DUCK_ERR_SETUP = -5100,
+    /// Invalid argument
+    DUCK_ERR_INVALID_ARGUMENT = -5101,
+    /// Device Id is too long
+    DUCK_ERR_ID_TOO_LONG = -5101,
 
-// Invalid argument
-#define DUCK_ERR_INVALID_ARGUMENT -5101
+    /// Lora module initialization error
+    DUCKLORA_ERR_BEGIN = -1000,
+    /// Lora module configuration error
+    DUCKLORA_ERR_SETUP = -1001,
+    /// Failure to read data from the Lora module
+    DUCKLORA_ERR_RECEIVE = -1002,
+    /// Lora module timeout error
+    DUCKLORA_ERR_TIMEOUT = -1003,
+    /// Failed to send data
+    DUCKLORA_ERR_TRANSMIT = -1004,
+    /// Failed to handle data received from the Lora module
+    DUCKLORA_ERR_HANDLE_PACKET = -1050,
+    /// Attempted to send a message larger than 256 bytes
+    DUCKLORA_ERR_MSG_TOO_LARGE = -1051,
+    /// Radio is busy sending data
+    DUCKLORA_ERR_TX_BUSY = -1052,
+    /// Invalid channel
+    DUCKLORA_ERR_INVALID_CHANNEL = -1053,
+    /// Radio not initialized
+    DUCKLORA_ERR_NOT_INITIALIZED = -1054,
+    /// Lora standby error
+    DUCKLORA_ERR_STANDBY = -1055,
+    /// Lora sleep error
+    DUCKLORA_ERR_SLEEP = -1056,
 
-// Device Id is too long
-#define DUCK_ERR_ID_TOO_LONG   -5101
+    /// Wifi network is not available
+    DUCKWIFI_ERR_NOT_AVAILABLE = -2000,
+    /// Wifi is disconnected
+    DUCKWIFI_ERR_DISCONNECTED = -2001,
+    /// Wifi generic setup error
+    DUCKWIFI_ERR_AP_CONFIG = -2002,
+    /// DNS initialization failed
+    DUCKDNS_ERR_STARTING = -3000,
 
-/// Lora module initialization error
-#define DUCKLORA_ERR_BEGIN          -1000
+    /// Packet size invalid
+    DUCKPACKET_ERR_SIZE_INVALID = -4000,
+    /// Packet topic invalid
+    DUCKPACKET_ERR_TOPIC_INVALID = -4001,
+    /// Packet max hops exceeded
+    DUCKPACKET_ERR_MAX_HOPS = -4002,
 
-/// Lora module configuration error
-#define DUCKLORA_ERR_SETUP          -1001
-/// Failure to read data from the Lora module
-#define DUCKLORA_ERR_RECEIVE        -1002
-/// Lora module timeout error
-#define DUCKLORA_ERR_TIMEOUT        -1003
-/// Failed to send data
-#define DUCKLORA_ERR_TRANSMIT       -1004
-/// Failed to handle data received from the Lora module
-#define DUCKLORA_ERR_HANDLE_PACKET  -1050
-/// Attempted to send a message larger than 256 bytes
-#define DUCKLORA_ERR_MSG_TOO_LARGE  -1051
-/// Radio is busy sending data
-#define DUCKLORA_ERR_TX_BUSY        -1052
-/// Invalid channel
-#define DUCKLORA_ERR_INVALID_CHANNEL -1053
-/// Radio not initialized
-#define DUCKLORA_ERR_NOT_INITIALIZED -1054
+    /// Internet setup error
+    DUCK_INTERNET_ERR_SETUP = -6000,
+    /// Internet SSID error
+    DUCK_INTERNET_ERR_SSID = -6001,
+    /// Internet connection error
+    DUCK_INTERNET_ERR_CONNECT = -6002,
 
-#define DUCKLORA_ERR_STANDBY         -1055
-#define DUCKLORA_ERR_SLEEP           -1056
+    /// EEPROM initialization error
+    DUCK_ERR_EEPROM_INIT = -7000,
+    /// EEPROM write error
+    DUCK_ERR_EEPROM_WRITE = -7001,
+    /// EEPROM read error
+    DUCK_ERR_EEPROM_READ = -7002
+};
 
+/// Get human-readable error string for a given error code
+/// @param error The error code
+/// @return A string describing the error
+inline const char* getDuckErrorString(int error) {
+    switch(error) {
+        case DUCK_ERR_NONE:
+            return "No Error";
+        case DUCK_ERR_NOT_SUPPORTED:
+            return "Feature not supported";
+        case DUCK_ERR_SETUP:
+            return "Failed to setup device";
+        case DUCK_ERR_INVALID_ARGUMENT:
+            return "Invalid argument";
+        case DUCK_ERR_ID_TOO_LONG:
+            return "Device Id is too long";
 
-/// Wifi network is not availble
-#define DUCKWIFI_ERR_NOT_AVAILABLE  -2000
-/// Wifi is disconnected
-#define DUCKWIFI_ERR_DISCONNECTED   -2001
-/// Wifi generic setup error
-#define DUCKWIFI_ERR_AP_CONFIG      -2002
-/// DNS initialization failed
-#define DUCKDNS_ERR_STARTING        -3000
+        case DUCKLORA_ERR_BEGIN:
+            return "Lora module initialization error";
+        case DUCKLORA_ERR_SETUP:
+            return "Lora module configuration error";
+        case DUCKLORA_ERR_RECEIVE:
+            return "Failure to read data from the Lora module";
+        case DUCKLORA_ERR_TIMEOUT:
+            return "Lora module timeout error";
+        case DUCKLORA_ERR_TRANSMIT:
+            return "Failed to send data";
+        case DUCKLORA_ERR_HANDLE_PACKET:
+            return "Failed to handle data received from the Lora module";
+        case DUCKLORA_ERR_MSG_TOO_LARGE:
+            return "Attempted to send a message larger than 256 bytes";
+        case DUCKLORA_ERR_TX_BUSY:
+            return "Radio is busy sending data";
+        case DUCKLORA_ERR_INVALID_CHANNEL:
+            return "Invalid channel";
+        case DUCKLORA_ERR_NOT_INITIALIZED:
+            return "Radio not initialized";
+        case DUCKLORA_ERR_STANDBY:
+            return "Lora standby error";
+        case DUCKLORA_ERR_SLEEP:
+            return "Lora sleep error";
 
+        case DUCKWIFI_ERR_NOT_AVAILABLE:
+            return "Wifi network is not available";
+        case DUCKWIFI_ERR_DISCONNECTED:
+            return "Wifi is disconnected";
+        case DUCKWIFI_ERR_AP_CONFIG:
+            return "Wifi generic setup error";
+        case DUCKDNS_ERR_STARTING:
+            return "DNS initialization failed";
 
-#define DUCKPACKET_ERR_SIZE_INVALID  -4000
-#define DUCKPACKET_ERR_TOPIC_INVALID -4001
-#define DUCKPACKET_ERR_MAX_HOPS      -4002
+        case DUCKPACKET_ERR_SIZE_INVALID:
+            return "Packet size invalid";
+        case DUCKPACKET_ERR_TOPIC_INVALID:
+            return "Packet topic invalid";
+        case DUCKPACKET_ERR_MAX_HOPS:
+            return "Packet max hops exceeded";
 
-#define DUCK_INTERNET_ERR_SETUP      -6000
-#define DUCK_INTERNET_ERR_SSID       -6001
-#define DUCK_INTERNET_ERR_CONNECT    -6002
-#define DUCK_ERR_EEPROM_INIT         -7000
-#define DUCK_ERR_EEPROM_WRITE        -7001
-#define DUCK_ERR_EEPROM_READ         -7002
+        case DUCK_INTERNET_ERR_SETUP:
+            return "Internet setup error";
+        case DUCK_INTERNET_ERR_SSID:
+            return "Internet SSID error";
+        case DUCK_INTERNET_ERR_CONNECT:
+            return "Internet connection error";
+
+        case DUCK_ERR_EEPROM_INIT:
+            return "EEPROM initialization error";
+        case DUCK_ERR_EEPROM_WRITE:
+            return "EEPROM write error";
+        case DUCK_ERR_EEPROM_READ:
+            return "EEPROM read error";
+
+        default:
+            return "Unknown error";
+    }
+}
 
 #endif


### PR DESCRIPTION
**Affected Areas:**

- [x] Code
- [x] Documentation
- [ ] Infrastructure

**Description:**  
There was some concern about publishes from the papaduck silently failing, This should print more expressive errors on packet build failures so that the papaduck doesn't need to be modified to catch them later. As always, check your telemetry prior to sending. The CDP makes no attempts to truncate  or compress long data sections.

**Related Issues:**  
#446
**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [x] Updated relevant documentation
- [ ] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [ ] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
