### PR TITLE
Quiet logging

### DIFF
--- a/src/radio/DuckLoRa.cpp
+++ b/src/radio/DuckLoRa.cpp
@@ -319,52 +319,52 @@ void DuckLoRa::serviceInterruptFlags() {
 #ifdef CDPCFG_RADIO_SX1262
         // SX1262 flags
         if (DuckLoRa::interruptFlags & RADIOLIB_SX126X_CMD_CLEAR_IRQ_STATUS) {
-            loginfo_ln("SX1262 Interrupt flag was set: clear IRQ status");
+            logdbg_ln("SX1262 Interrupt flag was set: clear IRQ status");
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX126X_CMD_CLEAR_DEVICE_ERRORS) {
-            loginfo_ln("SX1262 Interrupt flag was set: clear device errors");
+            logdbg_ln("SX1262 Interrupt flag was set: clear device errors");
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX126X_IRQ_CRC_ERR ) {
-            loginfo_ln("SX1262 Interrupt flag was set: payload CRC error");
+            logdbg_ln("SX1262 Interrupt flag was set: payload CRC error");
             goToReceiveMode(false);
             lora.standby();
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX126X_IRQ_HEADER_ERR ) {
-            loginfo_ln("SX1262 Interrupt flag was set: header CRC error");
+            logdbg_ln("SX1262 Interrupt flag was set: header CRC error");
             goToReceiveMode(false);
             lora.standby();
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX126X_IRQ_RX_DONE ) {
-            loginfo_ln("SX1262 Interrupt flag was set: packet reception complete");
+            logdbg_ln("SX1262 Interrupt flag was set: packet reception complete");
             setReceiveFlag(true);
             lora.standby(); // we are done receiving, go to standby. We can't sleep because read buffer is not empty
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX126X_IRQ_TX_DONE ) {
-            loginfo_ln("SX1262 Interrupt flag was set: payload transmission complete");
+            logdbg_ln("SX1262 Interrupt flag was set: payload transmission complete");
             lora.finishTransmit();
             goToReceiveMode(false);
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX126X_IRQ_TIMEOUT ) {
-            loginfo_ln("SX1262 Interrupt flag was set: timeout");
+            logdbg_ln("SX1262 Interrupt flag was set: timeout");
             goToReceiveMode(false);
         }
 #else
         // SX127X flags
         if (DuckLoRa::interruptFlags & RADIOLIB_SX127X_CLEAR_IRQ_FLAG_RX_TIMEOUT) {
             goToReceiveMode(true); // go back to receive mode and reset the receive flag
-            loginfo_ln("SX127x Interrupt flag was set: timeout");
+            logdbg_ln("SX127x Interrupt flag was set: timeout");
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX127X_CLEAR_IRQ_FLAG_RX_DONE) {
-            loginfo_ln("SX127x Interrupt flag was set: packet reception complete");
+            logdbg_ln("SX127x Interrupt flag was set: packet reception complete");
             setReceiveFlag(true); // set the receive flag and we stay in receive mode
             lora.standby(); // we are done receiving, go to standby. We can't sleep because read buffer is not empty
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX127X_CLEAR_IRQ_FLAG_PAYLOAD_CRC_ERROR) {
             goToReceiveMode(true); // go back to receive mode and reset the receive flag
-            loginfo_ln("SX127x Interrupt flag was set: payload CRC error");
+            logdbg_ln("SX127x Interrupt flag was set: payload CRC error");
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX127X_CLEAR_IRQ_FLAG_VALID_HEADER) {
-            loginfo_ln("SX127x Interrupt flag was set: valid header received");
+            logdbg_ln("SX127x Interrupt flag was set: valid header received");
         }
         if (DuckLoRa::interruptFlags & RADIOLIB_SX127X_CLEAR_IRQ_FLAG_TX_DONE) {
             loginfo_ln("SX127x Interrupt flag was set: payload transmission complete");

--- a/src/routing/DuckRouter.cpp
+++ b/src/routing/DuckRouter.cpp
@@ -1,15 +1,16 @@
 #include "DuckRouter.h"
 
 void DuckRouter::insertIntoRoutingTable(Duid deviceID, Duid nextHop, SignalScore signalInfo) {
-
     Neighbor neighborRecord(deviceID, nextHop, signalInfo, millis());
     auto index = routingTable.find(duckutils::toString(deviceID));
     if (index == routingTable.end()) { //need to make sure we aren't adding Link1276->Link1276 to Mama1262
+        logdbg_ln("Adding new neighbor record to routing table for deviceID: %s", duckutils::toString(deviceID));
         std::list<Neighbor> neighborList;
         neighborList.push_back(neighborRecord);
         routingTable.insert(std::make_pair(neighborRecord.getDeviceId(), neighborList));
     } else {
         // Update existing record
+        logdbg_ln("Updating existing neighbor record in routing table for deviceID: %s", duckutils::toString(deviceID));
         index->second.remove_if([neighborRecord](const Neighbor& n) {
             return n.getLastSeen() < neighborRecord.getLastSeen() && n.getDeviceId() == neighborRecord.getDeviceId();
         });
@@ -19,8 +20,10 @@ void DuckRouter::insertIntoRoutingTable(Duid deviceID, Duid nextHop, SignalScore
 
 std::optional<Duid> DuckRouter::getBestNextHop(Duid targetDeviceId){
     //check if nextHop = the duid of the last duid in path/last duid that relayed to the current duck so that it doesn't transmit back the way it came from
+    logdbg_ln("Searching for best next hop for target device ID: %s", duckutils::toString(targetDeviceId));
     auto nextHopRecord = routingTable.find(duckutils::toString(targetDeviceId));
     if (nextHopRecord == routingTable.end()) {
+        logdbg_ln("No routing entry found for target device ID: %s", duckutils::toString(targetDeviceId));
         return std::nullopt; // No entry found
     }
     nextHopRecord->second.sort(std::greater<>());


### PR DESCRIPTION
**Affected Areas:**

- [x] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
No real testing needed, no functionality has been changed, just the logging statement used. Flash and pass `-D CDP_DEBUG` in your `platformio.ini` build file if you want to independently verify.

**Related Issues:**  
#526, but also the PR #521 does some of the same edits. This one shouldn't conflict with it.
**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [x] Updated relevant documentation
- [x] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [x] T-Beam SoftRF sX1262
- [x] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
