### PR TITLE
Bloom filter fix

### DIFF
--- a/src/routing/bloomfilter.cpp
+++ b/src/routing/bloomfilter.cpp
@@ -178,14 +178,14 @@ void BloomFilter::bloom_add(unsigned char* msg, int msgSize) {
     if (this->nMsg >= this->maxMsgs) {
         if (this->activeFilter == 1){
             logdbg("Freezing filter 1, switching to filter 2\n");
-            for (int i = 0; i < (this->numSectors)/(this->bitsPerSector); i++) {
+            for (int i = 0; i < this->numSectors; i++) {
                     this->filter2[i] = 0;
             }
             this->activeFilter = 2;
         }
         else{
             logdbg("Freezing filter 2, switching to filter 1\n");
-            for (int i = 0; i < (this->numSectors)/(this->bitsPerSector); i++) {
+            for (int i = 0; i < this->numSectors; i++) {
                     this->filter1[i] = 0;
             }
             this->activeFilter = 1;


### PR DESCRIPTION
**Affected Areas:**

- [x] Code
- [ ] Documentation
- [ ] Infrastructure

**Description:**  
The bloom filter contains 2 arrays that hold data about "already seen" MUIDs. When switching between the filters, the inactive filter is cleared out first before becoming the active filter. The loops weren't zeroing out the entire array before making it active. This eventually leads to heavy saturation of the filter and many new messages will be flagged incorrectly as "already seen". This small fix is an adjustment to clear out the arrays completely before setting it as active.

**Related Issues:**  

**Checklist**
Before you contribute, please make sure you have read the [Contribution Guidelines](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/ClusterDuck-Protocol/ClusterDuck-Protocol/blob/master/CODE_OF_CONDUCT.md)

- [x] Updated relevant documentation
- [x] Validated changes by uploading to hardware

_Tested Targets (Please check all that apply)_

- [ ] Heltec LoRa v3
- [ ] Heltec LoRa v2
- [x] T-Beam SoftRF sX1262
- [ ] T-Beam SoftRF SX1276
- [ ] Other (Please list in PR description)
